### PR TITLE
fix(docker): add network host and flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ uvx toolfront "DATABASE-URL-1" "DATABASE-URL-2" [...] --api-key "YOUR-API-KEY"
 ---
 
 ### Running with Docker
-[![Add to Cursor with Docker](https://github.com/kruskal-labs/toolfront/blob/main/img/buttons/cursor_docker.png?raw=true)](https://cursor.com/install-mcp?name=toolfront&config=eyJjb21tYW5kIjoiZG9ja2VyIHJ1biBhbnRpZG1nL3Rvb2xmcm9udCBEQVRBQkFTRS1VUkwtMSBEQVRBQkFTRS1VUkwtMiAtLWFwaS1rZXkgWU9VUi1BUEktS0VZIn0=)
-[![Add to GitHub Copilot with Docker](https://github.com/kruskal-labs/toolfront/blob/main/img/buttons/copilot_docker.png?raw=true)](https://insiders.vscode.dev/redirect/mcp/install?name=toolfront&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22antidmg%2Ftoolfront%22%2C%22DATABASE-URL-1%22%2C%22DATABASE-URL-2%22%2C%22--api-key%22%2C%22YOUR-API-KEY%22%5D%7D)
+[![Add to Cursor with Docker](https://github.com/kruskal-labs/toolfront/blob/main/img/buttons/cursor_docker.png?raw=true)](https://cursor.com/install-mcp?name=toolfront&config=eyJjb21tYW5kIjoiZG9ja2VyIiwiYXJncyI6WyJydW4iLCItaSIsIi0tbmV0d29yayIsImhvc3QiLCJhbnRpZG1nL3Rvb2xmcm9udCIsIkRBVEFCQVNFLVVSTC0xIiwiREFUQUJBU0UtVVJMLTIiLCItLWFwaS1rZXkiLCJZT1VSLUFQSS1LRVkiXX0K)
+[![Add to GitHub Copilot with Docker](https://github.com/kruskal-labs/toolfront/blob/main/img/buttons/copilot_docker.png?raw=true)](https://insiders.vscode.dev/redirect/mcp/install?name=toolfront&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--network%22%2C%22host%22%2C%22antidmg%2Ftoolfront%22%2C%22DATABASE-URL-1%22%2C%22DATABASE-URL-2%22%2C%22--api-key%22%2C%22YOUR-API-KEY%22%5D%7D)
 
 <br>
 
@@ -76,6 +76,8 @@ Add this to your MCP config file to connect coding agents to ToolFront with Dock
     "command": "docker",
     "args": [
       "run",
+      "-i",
+      "--network", "host",
       "antidmg/toolfront",
       "DATABASE-URL-1",
       "DATABASE-URL-2",
@@ -86,10 +88,13 @@ Add this to your MCP config file to connect coding agents to ToolFront with Dock
 }
 ```
 
+> [!NOTE]
+> When using Docker with databases on localhost (like `postgresql://user:pass@localhost:5432/db`), include `--network host` to allow the container to access your host machine's databases.
+
 Alternatively, run the following command to download, pull, and run the ToolFront MCP container:
 
 ```bash
-docker run antidmg/toolfront "DATABASE-URL-1" "DATABASE-URL-2" [...] --api-key "YOUR-API-KEY"
+docker run -i --network host antidmg/toolfront "DATABASE-URL-1" "DATABASE-URL-2" [...] --api-key "YOUR-API-KEY"
 ```
 
 ## Collaborative In-context Learning

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ uvx toolfront "DATABASE-URL-1" "DATABASE-URL-2" [...] --api-key "YOUR-API-KEY"
 ---
 
 ### Running with Docker
-[![Add to Cursor with Docker](https://github.com/kruskal-labs/toolfront/blob/main/img/buttons/cursor_docker.png?raw=true)](https://cursor.com/install-mcp?name=toolfront&config=eyJjb21tYW5kIjoiZG9ja2VyIiwiYXJncyI6WyJydW4iLCItaSIsIi0tbmV0d29yayIsImhvc3QiLCJhbnRpZG1nL3Rvb2xmcm9udCIsIkRBVEFCQVNFLVVSTC0xIiwiREFUQUJBU0UtVVJMLTIiLCItLWFwaS1rZXkiLCJZT1VSLUFQSS1LRVkiXX0K)
-[![Add to GitHub Copilot with Docker](https://github.com/kruskal-labs/toolfront/blob/main/img/buttons/copilot_docker.png?raw=true)](https://insiders.vscode.dev/redirect/mcp/install?name=toolfront&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22--network%22%2C%22host%22%2C%22antidmg%2Ftoolfront%22%2C%22DATABASE-URL-1%22%2C%22DATABASE-URL-2%22%2C%22--api-key%22%2C%22YOUR-API-KEY%22%5D%7D)
+[![Add to Cursor with Docker](https://github.com/kruskal-labs/toolfront/blob/main/img/buttons/cursor_docker.png?raw=true)](https://cursor.com/install-mcp?name=toolfront&config=eyJjb21tYW5kIjoiZG9ja2VyIiwiYXJncyI6WyJydW4iLCItaSIsImFudGlkbWcvdG9vbGZyb250IiwiREFUQUJBU0UtVVJMLTEiLCJEQVRBQkFTRS1VUkwtMiIsIi0tYXBpLWtleSIsIllPVVItQVBJLUtFWSJdfQo=)
+[![Add to GitHub Copilot with Docker](https://github.com/kruskal-labs/toolfront/blob/main/img/buttons/copilot_docker.png?raw=true)](https://insiders.vscode.dev/redirect/mcp/install?name=toolfront&config=%7B%22command%22%3A%22docker%22%2C%22args%22%3A%5B%22run%22%2C%22-i%22%2C%22antidmg%2Ftoolfront%22%2C%22DATABASE-URL-1%22%2C%22DATABASE-URL-2%22%2C%22--api-key%22%2C%22YOUR-API-KEY%22%5D%7D)
 
 <br>
 
@@ -77,7 +77,6 @@ Add this to your MCP config file to connect coding agents to ToolFront with Dock
     "args": [
       "run",
       "-i",
-      "--network", "host",
       "antidmg/toolfront",
       "DATABASE-URL-1",
       "DATABASE-URL-2",
@@ -88,13 +87,13 @@ Add this to your MCP config file to connect coding agents to ToolFront with Dock
 }
 ```
 
-> [!NOTE]
-> When using Docker with databases on localhost (like `postgresql://user:pass@localhost:5432/db`), include `--network host` to allow the container to access your host machine's databases.
+> [!TIP]
+> **Localhost databases**: When connecting to databases on localhost (like `postgresql://user:pass@localhost:5432/db`), add `--network host` before the image name. Remote databases (cloud, external servers) work without this flag.
 
 Alternatively, run the following command to download, pull, and run the ToolFront MCP container:
 
 ```bash
-docker run -i --network host antidmg/toolfront "DATABASE-URL-1" "DATABASE-URL-2" [...] --api-key "YOUR-API-KEY"
+docker run -i antidmg/toolfront "DATABASE-URL-1" "DATABASE-URL-2" [...] --api-key "YOUR-API-KEY"
 ```
 
 ## Collaborative In-context Learning


### PR DESCRIPTION
- Add `-i` and `--network host` flags to Docker commands in README
- Include note about localhost database access requirements
- Update Cursor and GitHub Copilot deeplink buttons with correct config
- Resolves Docker networking issues when connecting to host databases