### PR TITLE
make document dependencies optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ trino = [
 ]
 document = [
     "docling>=2.43.0",
-    "markitdown[pdf,docx,pptx,xlsx,xls]>=0.1.2",
+    "markitdown[docx,pdf,pptx,xls,xlsx]>=0.1.2",
 ]
 
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,6 @@ dependencies = [
     "ibis-framework>=10.6.0",
     "pyarrow<19.0.0",
     "executing>=2.2.0",
-    "docling>=2.43.0",
-    "markitdown[docx,pdf,pptx,xls,xlsx]>=0.1.2",
 ]
 
 [project.scripts]
@@ -97,6 +95,7 @@ trino = [
     "ibis-framework[trino]>=10.6.0",
 ]
 document = [
+    "docling>=2.43.0",
     "markitdown[pdf,docx,pptx,xlsx,xls]>=0.1.2",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "toolfront"
-version = "0.2.2"
+version = "0.2.3"
 description = "ToolFront helps you retrieve information from large databases, APIs, and documents with AI."
 readme = "README.md"
 authors = [

--- a/src/toolfront/__init__.py
+++ b/src/toolfront/__init__.py
@@ -1,5 +1,11 @@
 from toolfront.models.api import API
 from toolfront.models.database import Database
-from toolfront.models.document import Document
 
-__all__ = ["API", "Database", "Document"]
+__all__ = ["API", "Database"]
+
+try:
+    from toolfront.models.document import Document
+    __all__.append("Document")
+except ImportError:
+    # Document functionality not available without optional dependencies
+    pass


### PR DESCRIPTION
`markitdown` is ridiculously bloated, and pulls in `magika`/`onnx` by default