### PR TITLE
feat: add Google Analytics for documentation page

### DIFF
--- a/docs/assets/js/analytics.js
+++ b/docs/assets/js/analytics.js
@@ -1,0 +1,77 @@
+// Simple analytics for ToolFront docs - tracks what people actually use
+document.addEventListener('DOMContentLoaded', function() {
+    // Only run if gtag is available
+    if (typeof gtag === 'undefined') return;
+    
+    // Track which database/AI model pages are viewed
+    const path = window.location.pathname;
+    let contentType = null;
+    let contentName = null;
+    
+    if (path.includes('/databases/')) {
+        contentType = 'database';
+        contentName = path.split('/databases/')[1].replace(/\.(html|md)$/, '');
+    } else if (path.includes('/ai_models/')) {
+        contentType = 'ai_model';
+        contentName = path.split('/ai_models/')[1].replace(/\.(html|md)$/, '');
+    } else if (path.includes('/examples/')) {
+        contentType = 'example';
+        contentName = path.split('/examples/')[1].replace(/\.(html|md)$/, '');
+    }
+    
+    if (contentType && contentName) {
+        gtag('event', 'content_view', {
+            'content_type': contentType,
+            'content_name': contentName,
+            'page_path': path
+        });
+    }
+    
+    // Track section views (which parts of docs are most useful)
+    const section = path.split('/')[1] || 'home';
+    gtag('event', 'section_view', {
+        'section_name': section,
+        'page_title': document.title
+    });
+    
+    // Track searches to understand what's missing/hard to find
+    const searchInput = document.querySelector('.md-search__input');
+    if (searchInput) {
+        let searchTimer;
+        searchInput.addEventListener('input', function(e) {
+            clearTimeout(searchTimer);
+            searchTimer = setTimeout(function() {
+                if (e.target.value.length > 3) {
+                    gtag('event', 'search', {
+                        'search_term': e.target.value
+                    });
+                }
+            }, 1500); // Only track if user pauses typing
+        });
+    }
+    
+    // Track code copying to see what integrations people are building
+    document.addEventListener('click', function(e) {
+        if (e.target.closest('.md-clipboard')) {
+            const codeBlock = e.target.closest('.highlight');
+            const heading = findPreviousHeading(codeBlock);
+            
+            gtag('event', 'code_copy', {
+                'page_section': heading ? heading.textContent : 'unknown',
+                'page_path': path
+            });
+        }
+    });
+    
+    function findPreviousHeading(element) {
+        if (!element) return null;
+        let current = element.previousElementSibling;
+        while (current) {
+            if (current.tagName && current.tagName.match(/^H[1-6]$/)) {
+                return current;
+            }
+            current = current.previousElementSibling;
+        }
+        return null;
+    }
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,9 +149,13 @@ extra_javascript:
   - https://unpkg.com/aos@2.3.1/dist/aos.js
   - https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.js
   - assets/js/marquee.js
+  - assets/js/analytics.js
 
 extra:
   generator: false
+  analytics:
+    provider: google
+    property: !ENV GOOGLE_ANALYTICS_ID
   social:
     - icon: fontawesome/brands/discord
       link: https://discord.gg/rRyM7zkZTf


### PR DESCRIPTION
Add some bare bones analytics for anonymized page views, clicking, and scrolling. See if we can make exactly what we're tracking open source and transparent too.